### PR TITLE
change IBM_CLOUD_API_KEY to secure

### DIFF
--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -16,7 +16,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Build
     type: builder
@@ -87,7 +87,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Staging Gate
     type: tester
@@ -183,7 +183,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Production Gate
     type: tester

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -55,7 +55,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Deploy
     type: deployer
@@ -150,7 +150,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Production Gate
     type: tester

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -54,7 +54,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Deploy
     type: deployer
@@ -134,7 +134,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Production Gate
     type: tester


### PR DESCRIPTION
Should we set the API Key to be secure in the properties?  This will prevent it from being seen as clear text when viewing properties.