### PR TITLE
Update the template to send build and deploy records using CLI

### DIFF
--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -76,7 +76,7 @@ stages:
     type: text
   - name: SAUCE_ACCESS_KEY
     value: {{services.test.parameters.key}}
-    type: text
+    type: secure
   - name: LOGICAL_APP_NAME
     value: ${CF_APP_NAME}
     type: text

--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -41,6 +41,13 @@ stages:
         grunt_result=$?
         set -e
 
+        build_status="pass"
+        if [ $grunt_result -ne 0 ]; then
+            build_status="fail"
+        fi
+
+        idra --publishbuildrecord --branch=$GIT_BRANCH --repositoryurl=$GIT_URL --commitid=$GIT_COMMIT --status=$build_status
+
         idra --publishtestresult --filelocation=./tests/server/mochatest.xml --type=unittest
         idra --publishtestresult --filelocation=./tests/server/coverage/reports/coverage-summary.json --type=code
 
@@ -103,6 +110,8 @@ stages:
       api_key: ${API_KEY}
     script: |
       #!/bin/bash
+      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+
       SERVICE=$(cf services | grep myMicroservicesCloudant ||:)
       if [ ! -z "$SERVICE" ]; then
         PLAN=$(echo $SERVICE | awk '{print $3}')
@@ -121,9 +130,18 @@ stages:
       # Push app
       export CF_APP_NAME="staging-$CF_APP"
       cf push "${CF_APP_NAME}"
+      push_result=$?
       export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')      
       # View logs
       #cf logs "${CF_APP_NAME}" --recent
+
+      deploy_status="pass"
+      if [ $push_result -ne 0 ]; then
+         deploy_status="fail"
+      fi
+      npm install -g grunt-idra3
+      idra --publishdeployrecord  --env=$LOGICAL_ENV_NAME --status=$deploy_status --appurl=$APP_URL
+
   - name: Sauce Labs Tests
     type: tester
     extension_id: ibm.devops.services.pipeline.saucelabs
@@ -199,6 +217,8 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
+      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+
       SERVICE=$(cf services | grep myMicroservicesCloudant ||:)
       if [ ! -z "$SERVICE" ]; then
         PLAN=$(echo $SERVICE | awk '{print $3}')
@@ -233,3 +253,12 @@ stages:
         cf push $CF_APP
         cf delete $OLD_CF_APP -f
       fi
+
+      push_result=$?
+      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
+      deploy_status="pass"
+      if [ $push_result -ne 0 ]; then
+         deploy_status="fail"
+      fi
+      npm install -g grunt-idra3
+      idra --publishdeployrecord  --env=$LOGICAL_ENV_NAME --status=$deploy_status --appurl=$APP_URL

--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -40,7 +40,6 @@ stages:
       GRUNTFILE="tests/Gruntfile.js"
       if [ -f $GRUNTFILE ]; then
         export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
-        npm install -g npm@3.7.2 ### work around default npm 2.1.1 instability
         npm install
         npm install -g grunt-idra3
 
@@ -159,6 +158,7 @@ stages:
       GRUNTFILE="tests/Gruntfile.js"
       if [ -f $GRUNTFILE ]; then
         export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
+        npm install
         npm install -g grunt-idra3
         echo $APP_URL | grep "stage1"
         if [ $? -eq 0 ]; then

--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -16,10 +16,18 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Build
     type: builder
+    artifact_dir: ''
+    build_type: shell
+    script: |-
+      #!/bin/bash
+      export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
+      npm install
+      npm install -g grunt-idra3
+      idra --publishbuildrecord --branch=$GIT_BRANCH --repositoryurl=$GIT_URL --commitid=$GIT_COMMIT --status=pass
   - name: Unit Tests
     type: tester
     enable_tests: true
@@ -31,7 +39,7 @@ stages:
       #!/bin/bash
       GRUNTFILE="tests/Gruntfile.js"
       if [ -f $GRUNTFILE ]; then
-        export PATH=/opt/IBM/node-v4.2/bin:$PATH
+        export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
         npm install -g npm@3.7.2 ### work around default npm 2.1.1 instability
         npm install
         npm install -g grunt-idra3
@@ -40,13 +48,6 @@ stages:
         grunt dev-test-cov --no-color --gruntfile $GRUNTFILE --base .
         grunt_result=$?
         set -e
-
-        build_status="pass"
-        if [ $grunt_result -ne 0 ]; then
-            build_status="fail"
-        fi
-
-        idra --publishbuildrecord --branch=$GIT_BRANCH --repositoryurl=$GIT_URL --commitid=$GIT_COMMIT --status=$build_status
 
         idra --publishtestresult --filelocation=./tests/server/mochatest.xml --type=unittest
         idra --publishtestresult --filelocation=./tests/server/coverage/reports/coverage-summary.json --type=code
@@ -94,7 +95,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Staging Gate
     type: tester
@@ -110,7 +111,7 @@ stages:
       api_key: ${API_KEY}
     script: |
       #!/bin/bash
-      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
 
       SERVICE=$(cf services | grep myMicroservicesCloudant ||:)
       if [ ! -z "$SERVICE" ]; then
@@ -131,7 +132,7 @@ stages:
       export CF_APP_NAME="staging-$CF_APP"
       cf push "${CF_APP_NAME}"
       push_result=$?
-      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')      
+      export APP_URL=https://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')      
       # View logs
       #cf logs "${CF_APP_NAME}" --recent
 
@@ -157,8 +158,7 @@ stages:
       #!/bin/bash
       GRUNTFILE="tests/Gruntfile.js"
       if [ -f $GRUNTFILE ]; then
-        export PATH=/opt/IBM/node-v4.2/bin:$PATH
-        npm install
+        export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
         npm install -g grunt-idra3
         echo $APP_URL | grep "stage1"
         if [ $? -eq 0 ]; then
@@ -201,7 +201,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Production Gate
     type: tester
@@ -217,7 +217,7 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
-      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
 
       SERVICE=$(cf services | grep myMicroservicesCloudant ||:)
       if [ ! -z "$SERVICE" ]; then
@@ -255,7 +255,7 @@ stages:
       fi
 
       push_result=$?
-      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
+      export APP_URL=https://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
       deploy_status="pass"
       if [ $push_result -ne 0 ]; then
          deploy_status="fail"

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -124,6 +124,7 @@ stages:
       GRUNTFILE="tests/Gruntfile.js"
       if [ -f $GRUNTFILE ]; then
         export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
+        npm install
         npm install -g grunt-idra3
         echo $APP_URL | grep "stage1"
         if [ $? -eq 0 ]; then

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -16,7 +16,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Build
     type: builder
@@ -24,10 +24,10 @@ stages:
     build_type: shell
     script: |-
       #!/bin/bash
-      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
       npm install -g grunt-idra3
 
-      idra --publishbuildrecord --branch=$GIT_BRANCH --repositoryurl=$GIT_URL --commitid=$GIT_COMMIT --status="pass"
+      idra --publishbuildrecord --branch=$GIT_BRANCH --repositoryurl=$GIT_URL --commitid=$GIT_COMMIT --status=pass
 - name: STAGING
   inputs:
   - type: job
@@ -65,7 +65,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Deploy
     type: deployer
@@ -77,7 +77,7 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
-      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
 
       SERVICE=$(cf services | grep myMicroservicesCloudant ||:)
       if [ ! -z "$SERVICE" ]; then
@@ -98,7 +98,7 @@ stages:
       export CF_APP_NAME="staging-$CF_APP"
       cf push "${CF_APP_NAME}"
       push_result=$?
-      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')      
+      export APP_URL=https://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')      
       # View logs
       #cf logs "${CF_APP_NAME}" --recent
 
@@ -123,8 +123,7 @@ stages:
       #!/bin/bash
       GRUNTFILE="tests/Gruntfile.js"
       if [ -f $GRUNTFILE ]; then
-        export PATH=/opt/IBM/node-v4.2/bin:$PATH
-        npm install
+        export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
         npm install -g grunt-idra3
         echo $APP_URL | grep "stage1"
         if [ $? -eq 0 ]; then
@@ -170,7 +169,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Production Gate
     type: tester
@@ -186,7 +185,7 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
-      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
 
       SERVICE=$(cf services | grep myMicroservicesCloudant ||:)
       if [ ! -z "$SERVICE" ]; then
@@ -224,7 +223,7 @@ stages:
       fi
 
       push_result=$?
-      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
+      export APP_URL=https://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
 
       deploy_status="pass"
       if [ $push_result -ne 0 ]; then

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -14,6 +14,9 @@ stages:
   - name: BUILD_PREFIX
     value: master
     type: text
+  - name: IBM_CLOUD_API_KEY
+    value: ${INSIGHTS_API_KEY}
+    type: text
   jobs:
   - name: Build
     type: builder

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -47,7 +47,7 @@ stages:
     type: text
   - name: SAUCE_ACCESS_KEY
     value: {{services.test.parameters.key}}
-    type: text
+    type: secure
   - name: HOST
     value: ondemand.saucelabs.com
     type: text

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -67,6 +67,8 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
+      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+
       SERVICE=$(cf services | grep myMicroservicesCloudant ||:)
       if [ ! -z "$SERVICE" ]; then
         PLAN=$(echo $SERVICE | awk '{print $3}')
@@ -85,9 +87,17 @@ stages:
       # Push app
       export CF_APP_NAME="staging-$CF_APP"
       cf push "${CF_APP_NAME}"
+      push_result=$?
       export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')      
       # View logs
       #cf logs "${CF_APP_NAME}" --recent
+
+      deploy_status="pass"
+      if [ $push_result -ne 0 ]; then
+         deploy_status="fail"
+      fi
+      npm install -g grunt-idra3
+      idra --publishdeployrecord  --env=$LOGICAL_ENV_NAME --status=$deploy_status --appurl=$APP_URL
   - name: Sauce Labs Tests
     type: tester
     extension_id: ibm.devops.services.pipeline.saucelabs
@@ -166,6 +176,8 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
+      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+
       SERVICE=$(cf services | grep myMicroservicesCloudant ||:)
       if [ ! -z "$SERVICE" ]; then
         PLAN=$(echo $SERVICE | awk '{print $3}')
@@ -200,3 +212,13 @@ stages:
         cf push $CF_APP
         cf delete $OLD_CF_APP -f
       fi
+
+      push_result=$?
+      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
+
+      deploy_status="pass"
+      if [ $push_result -ne 0 ]; then
+         deploy_status="fail"
+      fi
+      npm install -g grunt-idra3
+      idra --publishdeployrecord  --env=$LOGICAL_ENV_NAME --status=$deploy_status --appurl=$APP_URL

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -18,6 +18,13 @@ stages:
   - name: Build
     type: builder
     artifact_dir: ''
+    build_type: shell
+    script: |-
+      #!/bin/bash
+      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      npm install -g grunt-idra3
+
+      idra --publishbuildrecord --branch=$GIT_BRANCH --repositoryurl=$GIT_URL --commitid=$GIT_COMMIT --status="pass"
 - name: STAGING
   inputs:
   - type: job

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -109,6 +109,7 @@ stages:
       GRUNTFILE="tests/Gruntfile.js"
       if [ -f $GRUNTFILE ]; then
         export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
+        npm install
         npm install -g grunt-idra3
         echo $APP_URL | grep "stage1"
         if [ $? -eq 0 ]; then

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -14,6 +14,9 @@ stages:
   - name: BUILD_PREFIX
     value: master
     type: text
+  - name: IBM_CLOUD_API_KEY
+    value: ${INSIGHTS_API_KEY}
+    type: text
   jobs:
   - name: Build
     type: builder

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -66,12 +66,22 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
+      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+
       # Push app
       export CF_APP_NAME="staging-$CF_APP"
       cf push "${CF_APP_NAME}"
+      push_result=$?
       export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')      
       # View logs
       #cf logs "${CF_APP_NAME}" --recent
+
+      deploy_status="pass"
+      if [ $push_result -ne 0 ]; then
+         deploy_status="fail"
+      fi
+      npm install -g grunt-idra3
+      idra --publishdeployrecord  --env=$LOGICAL_ENV_NAME --status=$deploy_status --appurl=$APP_URL
   - name: Sauce Labs Tests
     type: tester
     extension_id: ibm.devops.services.pipeline.saucelabs
@@ -150,6 +160,8 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
+      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+
       if ! cf app $CF_APP; then
         cf push $CF_APP
       else
@@ -169,3 +181,13 @@ stages:
         cf push $CF_APP
         cf delete $OLD_CF_APP -f
       fi
+
+      push_result=$?
+      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
+
+      deploy_status="pass"
+      if [ $push_result -ne 0 ]; then
+         deploy_status="fail"
+      fi
+      npm install -g grunt-idra3
+      idra --publishdeployrecord  --env=$LOGICAL_ENV_NAME --status=$deploy_status --appurl=$APP_URL

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -47,7 +47,7 @@ stages:
     type: text
   - name: SAUCE_ACCESS_KEY
     value: {{services.test.parameters.key}}
-    type: text
+    type: secure
   - name: HOST
     value: ondemand.saucelabs.com
     type: text

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -16,7 +16,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Build
     type: builder
@@ -24,10 +24,10 @@ stages:
     build_type: shell
     script: |-
       #!/bin/bash
-      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
       npm install -g grunt-idra3
 
-      idra --publishbuildrecord --branch=$GIT_BRANCH --repositoryurl=$GIT_URL --commitid=$GIT_COMMIT --status="pass"
+      idra --publishbuildrecord --branch=$GIT_BRANCH --repositoryurl=$GIT_URL --commitid=$GIT_COMMIT --status=pass
 - name: STAGING
   inputs:
   - type: job
@@ -65,7 +65,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Deploy
     type: deployer
@@ -77,13 +77,13 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
-      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
 
       # Push app
       export CF_APP_NAME="staging-$CF_APP"
       cf push "${CF_APP_NAME}"
       push_result=$?
-      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')      
+      export APP_URL=https://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')      
       # View logs
       #cf logs "${CF_APP_NAME}" --recent
 
@@ -108,8 +108,7 @@ stages:
       #!/bin/bash
       GRUNTFILE="tests/Gruntfile.js"
       if [ -f $GRUNTFILE ]; then
-        export PATH=/opt/IBM/node-v4.2/bin:$PATH
-        npm install
+        export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
         npm install -g grunt-idra3
         echo $APP_URL | grep "stage1"
         if [ $? -eq 0 ]; then
@@ -155,7 +154,7 @@ stages:
     type: text
   - name: IBM_CLOUD_API_KEY
     value: ${INSIGHTS_API_KEY}
-    type: text
+    type: secure
   jobs:
   - name: Production Gate
     type: tester
@@ -171,7 +170,7 @@ stages:
       api_key: ${API_KEY}
     script: |-
       #!/bin/bash
-      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
 
       if ! cf app $CF_APP; then
         cf push $CF_APP
@@ -194,7 +193,7 @@ stages:
       fi
 
       push_result=$?
-      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
+      export APP_URL=https://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
 
       deploy_status="pass"
       if [ $push_result -ne 0 ]; then

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -17,6 +17,14 @@ stages:
   jobs:
   - name: Build
     type: builder
+    artifact_dir: ''
+    build_type: shell
+    script: |-
+      #!/bin/bash
+      export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      npm install -g grunt-idra3
+
+      idra --publishbuildrecord --branch=$GIT_BRANCH --repositoryurl=$GIT_URL --commitid=$GIT_COMMIT --status="pass"
 - name: STAGING
   inputs:
   - type: job

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Get started with this sample, which is an online store that consists of three microservices: a Catalog API, an Orders API, and a UI that calls both of the APIs. The sample includes a DevOps toolchain that is preconfigured for continuous delivery, hosted Git source control, functional testing, issue tracking, online editing, and messaging. 
 
 ### To get started, click this button:
-[![Create Toolchain](https://console.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.bluemix.net/devops/setup/deploy?repository=https://github.com/open-toolchain/microservices-toolchain-hosted&refreshServices)
+[![Create Toolchain](https://cloud.ibm.com/devops/graphics/create_toolchain_button.png)](https://cloud.ibm.com/devops/setup/deploy?repository=https://github.com/open-toolchain/microservices-toolchain-hosted&refreshServices&env_id=ibm:yp:us-south)
  
 
 ---


### PR DESCRIPTION
1. Updated the template to send build record in the build job and deploy record in the deploy job. We are moving away from relying on the events sent by OTC when a build and deploy jobs complete. If a build (or deploy) record is already uploaded using the CLI, then the events are ignored.

2. Changed the IBM_CLOUD_API_KEY to be a secured value.

3. Changed the SAUCE_ACCESS_KEY to be a secured value.

4. Changed the APP_URL to be https.