### PR TITLE
add quotes around moustache expressions

### DIFF
--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -51,10 +51,10 @@ stages:
     value: undefined
     type: text
   - name: SAUCE_USERNAME
-    value: {{services.test.parameters.username}}
+    value: '{{services.test.parameters.username}}'
     type: text
   - name: SAUCE_ACCESS_KEY
-    value: {{services.test.parameters.key}}
+    value: '{{services.test.parameters.key}}'
     type: secure
   - name: HOST
     value: ondemand.saucelabs.com

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -26,10 +26,10 @@ stages:
     value: undefined
     type: text
   - name: SAUCE_USERNAME
-    value: {{services.test.parameters.username}}
+    value: '{{services.test.parameters.username}}'
     type: text
   - name: SAUCE_ACCESS_KEY
-    value: {{services.test.parameters.key}}
+    value: '{{services.test.parameters.key}}'
     type: secure
   - name: HOST
     value: ondemand.saucelabs.com

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -25,10 +25,10 @@ stages:
     value: undefined
     type: text
   - name: SAUCE_USERNAME
-    value: {{services.test.parameters.username}}
+    value: '{{services.test.parameters.username}}'
     type: text
   - name: SAUCE_ACCESS_KEY
-    value: {{services.test.parameters.key}}
+    value: '{{services.test.parameters.key}}'
     type: secure
   - name: HOST
     value: ondemand.saucelabs.com


### PR DESCRIPTION
to avoid problem in Washington D.C, using branch public-eu-de,
was seeing {[object Object]=null}
in json instead of expected
moustache expression: {{services.test.parameters.username}}