### PR TITLE
add quotes around moustache, on master

### DIFF
--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -83,10 +83,10 @@ stages:
     value: undefined
     type: text
   - name: SAUCE_USERNAME
-    value: {{services.test.parameters.username}}
+    value: '{{services.test.parameters.username}}'
     type: text
   - name: SAUCE_ACCESS_KEY
-    value: {{services.test.parameters.key}}
+    value: '{{services.test.parameters.key}}'
     type: secure
   - name: HOST
     value: ondemand.saucelabs.com

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -46,10 +46,10 @@ stages:
     value: undefined
     type: text
   - name: SAUCE_USERNAME
-    value: {{services.test.parameters.username}}
+    value: '{{services.test.parameters.username}}'
     type: text
   - name: SAUCE_ACCESS_KEY
-    value: {{services.test.parameters.key}}
+    value: '{{services.test.parameters.key}}'
     type: secure
   - name: HOST
     value: ondemand.saucelabs.com

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -46,10 +46,10 @@ stages:
     value: undefined
     type: text
   - name: SAUCE_USERNAME
-    value: {{services.test.parameters.username}}
+    value: '{{services.test.parameters.username}}'
     type: text
   - name: SAUCE_ACCESS_KEY
-    value: {{services.test.parameters.key}}
+    value: '{{services.test.parameters.key}}'
     type: secure
   - name: HOST
     value: ondemand.saucelabs.com


### PR DESCRIPTION
update the master branch used in the Dallas region
to add quotes around the moustache expressions,
to be consistent with the public-eu-de branch
used in the Tokyo and WashingtonDC regions.

The public-eu-de beanch had been changed in:
add quotes around moustache expressions
https://github.com/open-toolchain/microservices-toolchain-hosted/pull/57