### PR TITLE
installed grunt-cli globally in test jobs

### DIFF
--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -45,6 +45,7 @@ stages:
       if [ -f $GRUNTFILE ]; then
         export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
         npm install
+        npm install -g grunt-cli
 
         set +e
         grunt dev-test-cov --no-color --gruntfile $GRUNTFILE --base .
@@ -171,6 +172,8 @@ stages:
       if [ -f $GRUNTFILE ]; then
         export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
         npm install
+        npm install -g grunt-cli
+
         echo $APP_URL | grep "test"
         if [ $? -eq 0 ]; then
           grunt test_fake --gruntfile $GRUNTFILE --base .

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -120,7 +120,8 @@ stages:
       if [ -f $GRUNTFILE ]; then
         export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
         npm install
-        npm install -g grunt-idra3
+        npm install -g grunt-cli
+
         echo $APP_URL | grep "test"
         if [ $? -eq 0 ]; then
           grunt test_fake --gruntfile $GRUNTFILE --base .

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -105,6 +105,8 @@ stages:
       if [ -f $GRUNTFILE ]; then
         export PATH=/opt/IBM/node-v6.7.0/bin:$PATH
         npm install
+        npm install -g grunt-cli
+
         echo $APP_URL | grep "test"
         if [ $? -eq 0 ]; then
           grunt test_fake --gruntfile $GRUNTFILE --base .


### PR DESCRIPTION
installed grunt-cli globally because cd base image 2.x no longer includes grunt cli by default

[Quoting CD Pipeline docs](https://cloud.ibm.com/docs/services/ContinuousDelivery/pipeline_versioned_base_images?topic=ContinuousDelivery-pipeline_versioned_base_images#pipeline_versioned_base_images)
```After version 2.0, images no longer include grunt or python. You can choose to install grunt or python, if required.```