### PR TITLE
Removed test formats from policies for DevOps Insights

### DIFF
--- a/.bluemix/criteria.json
+++ b/.bluemix/criteria.json
@@ -6,7 +6,6 @@
       {
         "name": "Unit Test Rule",
         "description": "Unit Test Rule",
-        "format":"xunit",
         "stage":"unittest",
         "percentPass":100,
         "regressionCheck":true,
@@ -17,7 +16,6 @@
       {
         "name": "Functional Test Rule",
         "description": "Functional Test Rule",
-        "format":"xunit",
         "stage":"fvt",
         "percentPass":100,
         "regressionCheck":true,
@@ -28,7 +26,6 @@
       {
         "name": "Code Coverage Rule",
         "description": "Code Coverage Rule",
-        "format":"istanbul",
         "stage":"code",
         "codeCoverage":80,
         "regressionCheck":true
@@ -42,7 +39,6 @@
       {
         "name": "Unit Test Rule",
         "description": "Unit Test Rule",
-        "format":"xunit",
         "stage":"unittest",
         "percentPass":100,
         "regressionCheck":true,
@@ -53,7 +49,6 @@
       {
         "name": "Code Coverage Rule",
         "description": "Code Coverage Rule",
-        "format":"istanbul",
         "stage":"code",
         "codeCoverage":60
       }
@@ -66,7 +61,6 @@
       {
         "name": "Functional Test Rule",
         "description": "Functional Test Rule",
-        "format":"xunit",
         "stage":"fvt",
         "percentPass":100,
         "regressionCheck":true,


### PR DESCRIPTION
DevOps Insights UI no longer require users to specify test formats when creating policies. Toolchain creation template modified to reflect this new change.