### PR TITLE
fix deploy error plan not found

### DIFF
--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -130,12 +130,12 @@ stages:
           echo "Note: This can fail if the service is still bound to apps or service keys."
           echo "      If so, please delete these apps or service keys explicitly first."
           cf delete-service myMicroservicesCloudant -f
-          cf create-service cloudantNoSQLDB Lite myMicroservicesCloudant
+          cf create-service cloudantNoSQLDB lite myMicroservicesCloudant
         else
           echo "Keeping existing service (myMicroservicesCloudant:$PLAN)."
         fi
       else
-        cf create-service cloudantNoSQLDB Lite myMicroservicesCloudant
+        cf create-service cloudantNoSQLDB lite myMicroservicesCloudant
       fi
       # Push app
       export CF_APP_NAME="staging-$CF_APP"
@@ -247,12 +247,12 @@ stages:
           echo "Note: This can fail if the service is still bound to apps or service keys."
           echo "      If so, please delete these apps or service keys explicitly first."
           cf delete-service myMicroservicesCloudant -f
-          cf create-service cloudantNoSQLDB Lite myMicroservicesCloudant
+          cf create-service cloudantNoSQLDB lite myMicroservicesCloudant
         else
           echo "Keeping existing service (myMicroservicesCloudant:$PLAN)."
         fi
       else
-        cf create-service cloudantNoSQLDB Lite myMicroservicesCloudant
+        cf create-service cloudantNoSQLDB lite myMicroservicesCloudant
       fi
       if ! cf app $CF_APP; then
         cf push $CF_APP

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -78,12 +78,12 @@ stages:
           echo "Note: This can fail if the service is still bound to apps or service keys."
           echo "      If so, please delete these apps or service keys explicitly first."
           cf delete-service myMicroservicesCloudant -f
-          cf create-service cloudantNoSQLDB Lite myMicroservicesCloudant
+          cf create-service cloudantNoSQLDB lite myMicroservicesCloudant
         else
           echo "Keeping existing service (myMicroservicesCloudant:$PLAN)."
         fi
       else
-        cf create-service cloudantNoSQLDB Lite myMicroservicesCloudant
+        cf create-service cloudantNoSQLDB lite myMicroservicesCloudant
       fi
       # Push app
       export CF_APP_NAME="staging-$CF_APP"
@@ -198,12 +198,12 @@ stages:
           echo "Note: This can fail if the service is still bound to apps or service keys."
           echo "      If so, please delete these apps or service keys explicitly first."
           cf delete-service myMicroservicesCloudant -f
-          cf create-service cloudantNoSQLDB Lite myMicroservicesCloudant
+          cf create-service cloudantNoSQLDB lite myMicroservicesCloudant
         else
           echo "Keeping existing service (myMicroservicesCloudant:$PLAN)."
         fi
       else
-        cf create-service cloudantNoSQLDB Lite myMicroservicesCloudant
+        cf create-service cloudantNoSQLDB lite myMicroservicesCloudant
       fi
       if ! cf app $CF_APP; then
         cf push $CF_APP


### PR DESCRIPTION
the catalog and order pipeline
deploy stages were failing with an error:
> The plan Lite could not be found for service cloudantNoSQLDB

when attempting to do:
$ cf create-service cloudantNoSQLDB Lite myMicroservicesCloudant

fix is to change to a lower case 'L', like:
$ cf create-service cloudantNoSQLDB lite myMicroservicesCloudant